### PR TITLE
Add: Summary of ALBERT paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ XLNet: Generalized Autoregressive Pretraining for Language Understanding -- [Sum
 
 Fine-Tuning GPT-2 from Human Preferences — [Summary](https://openai.com/blog/fine-tuning-gpt-2/), [Paper](https://arxiv.org/abs/1909.08593)
 
+ALBERT: A Lite BERT for Self-Supervised Learning Of Language Representations — [Summary](https://amitness.com/2020/02/albert-visual-summary/), [Paper](https://arxiv.org/abs/1909.11942) 
+
 ## Multi-Task Learning
 
 A Hierarchical Multi-task Approach for Learning Embeddings from Semantic Tasks -- [Summary](https://medium.com/dair-ai/hmtl-multi-task-learning-for-state-of-the-art-nlp-245572bbb601), [Paper](https://arxiv.org/abs/1811.06031)


### PR DESCRIPTION
Hi @omarsar,

I have added a link to visual summary of the "ALBERT" paper under the "Language Modeling" section. Thanks.